### PR TITLE
Adds an option  exporter.information_schema_stats_expiry

### DIFF
--- a/collector/exporter_test.go
+++ b/collector/exporter_test.go
@@ -114,6 +114,17 @@ func TestExporterWithOpts(t *testing.T) {
 			convey.So(exporter.dsn, convey.ShouldEqual, "root@/mysql?log_slow_filter=%27tmp_table_on_disk,filesort_on_disk%27")
 		})
 
+		convey.Convey("SetInformationSchemaStatsExpiry", func() {
+			exporter := New(
+				context.Background(),
+				dsn,
+				[]Scraper{},
+				promslog.NewNopLogger(),
+				SetInformationSchemaStatsExpiry(120),
+			)
+			convey.So(exporter.dsn, convey.ShouldEqual, "root@/mysql?information_schema_stats_expiry=120")
+		})
+
 		convey.Convey("All options enabled", func() {
 			exporter := New(
 				context.Background(),
@@ -123,8 +134,9 @@ func TestExporterWithOpts(t *testing.T) {
 				EnableLockWaitTimeout(true),
 				SetLockWaitTimeout(30),
 				SetSlowLogFilter(true),
+				SetInformationSchemaStatsExpiry(0),
 			)
-			convey.So(exporter.dsn, convey.ShouldEqual, "root@/mysql?lock_wait_timeout=30&log_slow_filter=%27tmp_table_on_disk,filesort_on_disk%27")
+			convey.So(exporter.dsn, convey.ShouldEqual, "root@/mysql?lock_wait_timeout=30&log_slow_filter=%27tmp_table_on_disk,filesort_on_disk%27&information_schema_stats_expiry=0")
 		})
 
 		convey.Convey("All options with existing query parameter", func() {
@@ -137,8 +149,9 @@ func TestExporterWithOpts(t *testing.T) {
 				EnableLockWaitTimeout(true),
 				SetLockWaitTimeout(30),
 				SetSlowLogFilter(true),
+				SetInformationSchemaStatsExpiry(0),
 			)
-			convey.So(exporter.dsn, convey.ShouldEqual, "root@/mysql?parseTime=true&lock_wait_timeout=30&log_slow_filter=%27tmp_table_on_disk,filesort_on_disk%27")
+			convey.So(exporter.dsn, convey.ShouldEqual, "root@/mysql?parseTime=true&lock_wait_timeout=30&log_slow_filter=%27tmp_table_on_disk,filesort_on_disk%27&information_schema_stats_expiry=0")
 		})
 	})
 }

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -69,6 +69,10 @@ var (
 		"exporter.enable_lock_wait_timeout",
 		"Enable the lock_wait_timeout MySQL connection parameter.",
 	).Default("true").Bool()
+	informationSchemaStatsExpiry = kingpin.Flag(
+		"exporter.information_schema_stats_expiry",
+		"Set the information_schema_stats_expiry (in seconds) on the connection to control how often the server refreshes table statistics.",
+	).Default("86400").Int()
 	slowLogFilter = kingpin.Flag(
 		"exporter.log_slow_filter",
 		"Add a log_slow_filter to avoid slow query logging of scrapes. NOTE: Not supported by Oracle MySQL.",
@@ -215,6 +219,7 @@ func newHandler(scrapers []collector.Scraper, logger *slog.Logger) http.HandlerF
 		registry.MustRegister(collector.New(ctx, dsn, filteredScrapers, logger,
 			collector.EnableLockWaitTimeout(*enableExporterLockTimeout),
 			collector.SetLockWaitTimeout(*exporterLockTimeout),
+			collector.SetInformationSchemaStatsExpiry(*informationSchemaStatsExpiry),
 			collector.SetSlowLogFilter(*slowLogFilter),
 		))
 


### PR DESCRIPTION
```     
--exporter.information_schema_stats_expiry=86400
    Set the information_schema_stats_expiry (in seconds) on the connection to control how often the server refreshes table statistics.
```

This way one can control how "fresh" the data in the information_schema is without having full control over the global variables (such as in Google Cloud SQL)